### PR TITLE
Oc 742 po number add to payment update zd

### DIFF
--- a/checkout/payment/checkout.payment.js
+++ b/checkout/payment/checkout.payment.js
@@ -177,7 +177,10 @@ function CheckoutPaymentController($state, Underscore, toastr, OrderCloud, Avail
     function SavePONumber(index,order) {
         !vm.currentOrderPayments[index].xp ? vm.currentOrderPayments[index].xp = {} : vm.currentOrderPayments[index].xp;
         if (vm.currentOrderPayments[index].Type === "PurchaseOrder") {
-            OrderCloud.Payments.Update(order.ID, vm.currentOrderPayments[index].ID, vm.currentOrderPayments[index]);
+            OrderCloud.Payments.Update(order.ID, vm.currentOrderPayments[index].ID, vm.currentOrderPayments[index])
+                .then(function(){
+                    toastr.success('PO Number added to Order', 'Success:');
+                })
         }
     }
 

--- a/checkout/payment/templates/payment.tpl.html
+++ b/checkout/payment/templates/payment.tpl.html
@@ -13,7 +13,7 @@
         <div ng-switch-when="PurchaseOrder">
             <label for="poNumber">PO Number</label>
             <div class="input-group">
-                <input id="poNumber" class="form-control" type="text" ng-model="checkoutPayment.currentOrderPayments[this.$index].xp.PONumber"/>
+                <input id="poNumber" class="form-control" type="text" placeholder="Click '+' to add entered PO Number to order" ng-model="checkoutPayment.currentOrderPayments[this.$index].xp.PONumber"/>
                 <span class="input-group-btn"><button class="btn btn-success" ng-click="checkoutPayment.savePONumber(this.$index, checkout.currentOrder)"><i class="fa fa-plus"></i> </button></span>
             </div>
         </div>


### PR DESCRIPTION
@olsonkr 
The PO Number was designed so that it was not required to be apart of the order. I added a place holder and a toaster to make it clear when the PO Number is added.
There was some discussion with Rob about having the order validation only happen once all the information is entered rather than every time an option is selected or changed. However, that would require some reworking of how the checkout is set up. Which should probably be another jira task.